### PR TITLE
Fix out of bounds read in DecodeToBitmap()

### DIFF
--- a/src/OpenJpegDotNet/IO/Reader.cs
+++ b/src/OpenJpegDotNet/IO/Reader.cs
@@ -147,7 +147,7 @@ namespace OpenJpegDotNet.IO
             unsafe
             {
                 var buf = (Buffer*)userData;
-                var bytesToRead = (int)Math.Min((ulong)buf->Length, bytes);
+                var bytesToRead = (int)Math.Min((ulong)(buf->Length - buf->Position), bytes);
                 if (bytesToRead > 0)
                 {
                     NativeMethods.cstd_memcpy(buffer, IntPtr.Add(buf->Data, buf->Position), bytesToRead);


### PR DESCRIPTION
Read goes out of bounds in Read() Need to account for buffer position